### PR TITLE
Make transformer a duplex stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,17 @@ if (cluster.isMaster) {
 
   // stdout is plain line-oriented logs, but we want to add timestamps
   var info = transformer({ timeStamp: true,
-                           tag: 'INFO',
-                           destination: process.stdout });
+                           tag: 'INFO' });
   // stderr will only be used for strack traces on crash, which are multi-line
   var error = transformer({ timeStamp: true,
                             tag: 'ERROR',
-                            destination: process.stdout,
                             mergeMultiline: true });
 
   // Each worker's stdout/stderr gets piped into our info and erro transformers
   cluster.on('fork', function(worker) {
     console.error('connecting worker');
-    worker.process.stdout.pipe(info);
-    worker.process.stderr.pipe(error);
+    worker.process.stdout.pipe(info).pipe(process.stdout);
+    worker.process.stderr.pipe(error).pipe(process.stdout);
   });
 
   //... cluster fork logic goes here ...

--- a/bin/t.js
+++ b/bin/t.js
@@ -1,4 +1,4 @@
 var opts = require('minimist')(process.argv.slice(2));
 var logger = require('..')(opts);
 
-process.stdin.pipe(logger);
+process.stdin.pipe(logger).pipe(process.stdout);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 
 var byline = require('byline');
 var through = require('through');
+var duplexer = require('duplexer');
 var moment = require('moment');
 
 module.exports = Logger;
@@ -17,13 +18,12 @@ var formatters = {
 
 function Logger(options) {
   var defaults = {
-    destination: process.stdout,
     format: 'text',
     mergeMultiline: false,
   };
   options = util._extend(defaults, options || {});
   var catcher = new byline.LineStream;
-  var pipeline = catcher;
+  var emitter = catcher;
   var transforms = [
     objectifier(),
   ];
@@ -51,14 +51,11 @@ function Logger(options) {
   // restore line endings that were removed by byline
   transforms.push(reLiner());
 
-  // last transform is the destination stream to pipe out to
-  transforms.push(options.destination);
-
   for (var t in transforms) {
-    pipeline = pipeline.pipe(transforms[t]);
+    emitter = emitter.pipe(transforms[t]);
   }
 
-  return catcher;
+  return duplexer(catcher, emitter);
 }
 
 function reLiner() {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "byline": "^4.1.1",
+    "duplexer": "^0.1.1",
     "minimist": "^0.1.0",
     "moment": "^2.6.0",
     "through": "^2.3.4"


### PR DESCRIPTION
Remove the destination option in favour of making the returned stream
a duplex stream allowing for src.pipe(transformer).pipe(destination).

This change breaks backward compatibility with the initial release.
