### PR TITLE
fix deprecated node 22 api

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -29,7 +29,7 @@ var formatters = {
 
 function Logger(options) {
   var defaults = JSON.parse(JSON.stringify(Logger.DEFAULTS));
-  options = util._extend(defaults, options || {});
+  options = Object.assign(defaults, options || {});
   var catcher = deLiner();
   var emitter = catcher;
   var transforms = [

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -29,7 +29,7 @@ var formatters = {
 
 function Logger(options) {
   var defaults = JSON.parse(JSON.stringify(Logger.DEFAULTS));
-  options = Object.assign(defaults, options || {});
+  options = Object.assign(defaults, options ?? {});
   var catcher = deLiner();
   var emitter = catcher;
   var transforms = [


### PR DESCRIPTION
in node 22 there is an error message by node with the code: [DEP0060]. See: https://nodejs.org/api/deprecations.html#dep0060-util_extend