### PR TITLE
fix:util._extend is deprecated in node 22

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -29,7 +29,7 @@ var formatters = {
 
 function Logger(options) {
   var defaults = JSON.parse(JSON.stringify(Logger.DEFAULTS));
-  options = util._extend(defaults, options || {});
+  options = Object.assign({}, defaults, options || {});
   var catcher = deLiner();
   var emitter = catcher;
   var transforms = [
@@ -103,7 +103,7 @@ function reLiner() {
 }
 
 function objectifier() {
-  return through(objectify, null, {autoDestroy: false});
+  return through(objectify, null, { autoDestroy: false });
 
   function objectify(line) {
     this.emit('data', {
@@ -127,7 +127,7 @@ function textFormatter(options) {
 
   function textify(logEvent) {
     var line = util.format('%s%s', textifyTags(logEvent.tag),
-                           logEvent.msg.toString());
+      logEvent.msg.toString());
     if (options.timeStamp) {
       line = util.format('%s %s', new Date(logEvent.time).toISOString(), line);
     }


### PR DESCRIPTION
When I run pnpm nx run-many -t serve, I get the following warning message:
```
(node:1232556) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```
It seems that using Object.assign() can fix this.